### PR TITLE
Endpoint de PUT /alunos/remover-orientador

### DIFF
--- a/src/api/entrypoints/alunos/views.py
+++ b/src/api/entrypoints/alunos/views.py
@@ -83,9 +83,9 @@ async def get_aluno_email(aluno_email: str, repository=Depends(get_repo())):
 async def get_alunos_por_orientador(orientador_id: int, repository=Depends(get_repo())):
     return await ServicoAluno(repository).buscar_alunos_por_orientador(orientador_id)
 
-@router.put("/remover-orientador/{aluno_id}", response_model=AlunoInDB)
+@router.put("/remover-orientador/", response_model=AlunoInDB)
 async def remover_orientador_aluno(aluno_id: int,token: str = Depends(oauth2_scheme), repository=Depends(get_repo())):
-    logger.info(f"Solicitado deleção de {aluno_id=} | Autenticando usuário atual.")
+    logger.info(f"Solicitado remoção do orientador do {aluno_id=} | Autenticando usuário atual.")
     coordenador_ou_professor: Professor = await ServicoTipoUsuario(repository).buscar_usuario_atual(
         token=token)
     logger.info(

--- a/src/api/entrypoints/alunos/views.py
+++ b/src/api/entrypoints/alunos/views.py
@@ -83,7 +83,7 @@ async def get_aluno_email(aluno_email: str, repository=Depends(get_repo())):
 async def get_alunos_por_orientador(orientador_id: int, repository=Depends(get_repo())):
     return await ServicoAluno(repository).buscar_alunos_por_orientador(orientador_id)
 
-@router.put("/remover-orientador/", response_model=AlunoInDB)
+@router.put("/{aluno_id}/remover-orientador/", response_model=AlunoInDB)
 async def remover_orientador_aluno(aluno_id: int,token: str = Depends(oauth2_scheme), repository=Depends(get_repo())):
     logger.info(f"Solicitado remoção do orientador do {aluno_id=} | Autenticando usuário atual.")
     coordenador_ou_professor: Professor = await ServicoTipoUsuario(repository).buscar_usuario_atual(

--- a/src/api/entrypoints/alunos/views.py
+++ b/src/api/entrypoints/alunos/views.py
@@ -69,7 +69,6 @@ async def atualizar_aluno(
 ):
     return await ServicoAluno(repository).atualizar_aluno(aluno_id, aluno)
 
-
 @router.get("/cpf/{aluno_cpf}", response_model=AlunoInDB)
 async def get_aluno_cpf(aluno_cpf: str, repository=Depends(get_repo())):
     return await ServicoAluno(repository).buscar_aluno_por_cpf(aluno_cpf)
@@ -83,3 +82,17 @@ async def get_aluno_email(aluno_email: str, repository=Depends(get_repo())):
 @router.get("/orientador/{orientador_id}", response_model=List[AlunoInDB])
 async def get_alunos_por_orientador(orientador_id: int, repository=Depends(get_repo())):
     return await ServicoAluno(repository).buscar_alunos_por_orientador(orientador_id)
+
+@router.put("/remover-orientador/{aluno_id}", response_model=AlunoInDB)
+async def remover_orientador_aluno(aluno_id: int,token: str = Depends(oauth2_scheme), repository=Depends(get_repo())):
+    logger.info(f"Solicitado deleção de {aluno_id=} | Autenticando usuário atual.")
+    coordenador_ou_professor: Professor = await ServicoTipoUsuario(repository).buscar_usuario_atual(
+        token=token)
+    logger.info(
+        f"{aluno_id=} {coordenador_ou_professor.id=} | "
+        f"Tipo usuário atual é {coordenador_ou_professor.usuario.tipo_usuario.titulo}."
+    )
+    if (coordenador_ou_professor.usuario.tipo_usuario.titulo != TipoUsuarioEnum.COORDENADOR) and (coordenador_ou_professor.usuario.tipo_usuario.titulo != TipoUsuarioEnum.PROFESSOR):
+        raise NaoAutorizadoException()
+    
+    return await ServicoAluno(repository).remover_orientador(aluno_id)

--- a/src/api/services/aluno.py
+++ b/src/api/services/aluno.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import List
 
 from fastapi import Depends
+from sqlalchemy import null
 from loguru import logger
 from passlib.context import CryptContext
 
@@ -151,3 +152,9 @@ class ServicoAluno(ServicoBase):
 
     async def buscar_dados_in_db_por_email(self, email: str) -> AlunoInDB:
         return self.tipo_usuario_in_db(await self.buscar_por_email(email))
+    
+    async def remover_orientador(self, aluno_id: int) -> AlunoInDB:
+        db_aluno: Aluno = await self._repo.buscar_por_id(aluno_id, Aluno)
+        db_aluno.orientador_id = 1
+
+        return self.tipo_usuario_in_db(db_aluno)

--- a/src/api/services/aluno.py
+++ b/src/api/services/aluno.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import List
 
 from fastapi import Depends
-from sqlalchemy import null
 from loguru import logger
 from passlib.context import CryptContext
 


### PR DESCRIPTION
## Descrição

Fixes #75.

Este PR contém as seguintes alterações: 

 - Criar endpoint de PUT /alunos/remover-orientador;
 - Receber apenas o parâmetro aluno_id no body;
 - Autenticar rota;
 - Checar se o token do usuário pertence ao tipo professor ou coordenador (se não pertencer, levantar exceção NaoAutorizadoException;
- Se o usuário for autorizado a remover o orientador, trocar o ID do orientador do aluno para ID 1 (será um professor padrão, chamado "Sem Orientador");


## Que tipo de PR é este? (marque todos os aplicáveis)

- [X] 🍕 Recurso (Feature)
- [ ] 🐛 Correção de Erro (Bugfix)
- [ ] 📝 Atualização de Documentação
- [ ] 🎨 Estilização
- [ ] 🧑‍💻 Refatoração de Código
- [ ] 🔥 Melhorias de Desempenho
- [ ] ✅ Testes (unitários/integração/e2e)
- [ ] 🤖 Compilação
- [ ] 🔁 Integração Contínua
- [ ] 📦 Tarefa (Nova versão)
- [ ] ⏩ Reverter

## Issues/Tickets e Documentos Relacionados



## Capturas de Tela/Gravações para Dispositivos Móveis e Desktop

![image](https://github.com/tauanesales/Sistema-PGCop-UFBA/assets/57494016/2a87c150-9161-4c30-9c59-87f6f409b91a)

## Passos para a QA

Testar endpoint de PUT /alunos/remover-orientador
Testar se recebe apenas o parâmetro aluno_id no body
Testar autenticação da rota com:
- Não autenticado
- Aluno
- Professor
- Coordenador
Validar se o retorno contém o "orientador_id" igual a 1

## Adicionado à Documentação?

## [opcional] Existem tarefas pós-implementação que precisamos realizar?

Não necessário