### PR TITLE
adição de autenticação para acessar endpoint /alunos/cpf/{aluno_cpf}

### DIFF
--- a/src/api/entrypoints/alunos/views.py
+++ b/src/api/entrypoints/alunos/views.py
@@ -55,8 +55,18 @@ async def deletar_aluno_atual(
 
 
 @router.get("/cpf/{aluno_cpf}", response_model=AlunoInDB)
-async def get_aluno_cpf(aluno_cpf: str, repository=Depends(get_repo())):
-    return await ServicoAluno(repository).buscar_aluno_por_cpf(aluno_cpf)
+async def get_aluno_cpf(aluno_cpf: str, repository=Depends(get_repo()),token: str = Depends(oauth2_scheme)):
+    professor: Professor = await ServicoTipoUsuarioGenerico(
+        repository
+    ).buscar_usuario_atual(token=token)
+
+    if professor.usuario.tipo_usuario.titulo not in [
+        TipoUsuarioEnum.COORDENADOR,
+        TipoUsuarioEnum.PROFESSOR,
+    ]:
+        raise NaoAutorizadoException()
+    else:
+        return await ServicoAluno(repository).buscar_aluno_por_cpf(aluno_cpf)
 
 
 @router.get("/email/{aluno_email}", response_model=AlunoInDB)


### PR DESCRIPTION
## Descrição
FIXES #82 

Implementações: 
- GET /alunos/cpf/{aluno_cpf} deve ser autenticado (receber token);
- Apenas professores e coordenadores devem ser capazes de buscar informação de aluno por CPF.


## Que tipo de PR é este? (marque todos os aplicáveis)
<!-- Caso tenha dificuldade em marcas os checkboxes, abra o PR primeiro e clique no checkbox posteriormente -->

- [x] 🍕 Recurso (Feature)
- [ ] 🐛 Correção de Erro (Bugfix)
- [ ] 📝 Atualização de Documentação
- [ ] 🎨 Estilização
- [ ] 🧑‍💻 Refatoração de Código
- [ ] 🔥 Melhorias de Desempenho
- [ ] ✅ Testes (unitários/integração/e2e)
- [ ] 🤖 Compilação
- [ ] 🔁 Integração Contínua
- [ ] 📦 Tarefa (Nova versão)
- [ ] ⏩ Reverter

## Issues/Tickets e Documentos Relacionados

#82 


## Capturas de Tela/Gravações para Dispositivos Móveis e Desktop

![image](https://github.com/user-attachments/assets/7054b04c-ebb7-4810-b7b9-4c7b52d8c7da)



## Passos para a QA

Testar acesso ao endpoint:
- Logado como professor / coordenador
- Logado como aluno
- Não logado

## Adicionado à Documentação?

## [opcional] Existem tarefas pós-implementação que precisamos realizar?

Não necessário

