### PR TITLE
autenticação na hora de deletar tarefas

### DIFF
--- a/src/api/entrypoints/tarefas/views.py
+++ b/src/api/entrypoints/tarefas/views.py
@@ -1,9 +1,12 @@
 from fastapi import APIRouter, Depends, status
 from fastapi.security import OAuth2PasswordBearer
-
+from src.api.database.models.professor import Professor
 from src.api.database.session import get_repo
 from src.api.entrypoints.tarefas.schema import TarefaAtualizada, TarefaBase, TarefaInDB
+from src.api.exceptions.credentials_exception import NaoAutorizadoException
 from src.api.services.tarefa import ServiceTarefa
+from src.api.services.tipo_usuario import ServicoTipoUsuarioGenerico
+from src.api.utils.enums import TipoUsuarioEnum
 
 router = APIRouter()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
@@ -22,7 +25,18 @@ async def atualizar_tarefa(
 
 
 @router.delete("/{tarefa_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def deletar_tarefa(tarefa_id: int, repository=Depends(get_repo())):
+async def deletar_tarefa(tarefa_id: int, token: str = Depends(oauth2_scheme), repository=Depends(get_repo())):
+    
+    professor: Professor = await ServicoTipoUsuarioGenerico(
+        repository
+    ).buscar_usuario_atual(token=token)
+
+    if professor.usuario.tipo_usuario.titulo not in [
+        TipoUsuarioEnum.COORDENADOR,
+        TipoUsuarioEnum.PROFESSOR,
+    ]:
+        raise NaoAutorizadoException()
+    
     await ServiceTarefa(repository).deletar_tarefa(tarefa_id)
     return {"ok": True}
 

--- a/src/api/entrypoints/tarefas_base/views.py
+++ b/src/api/entrypoints/tarefas_base/views.py
@@ -1,8 +1,8 @@
 from typing import List
-
 from fastapi import APIRouter, Depends, status
 from fastapi.security import OAuth2PasswordBearer
 
+from src.api.database.models.professor import Professor
 from src.api.database.session import get_repo
 from src.api.entrypoints.tarefas_base.schema import (
     CursoEnum,
@@ -10,7 +10,10 @@ from src.api.entrypoints.tarefas_base.schema import (
     TarefaBaseBase,
     TarefaBaseInDB,
 )
+from src.api.exceptions.credentials_exception import NaoAutorizadoException
 from src.api.services.tarefa_base import ServiceTarefaBase
+from src.api.services.tipo_usuario import ServicoTipoUsuarioGenerico
+from src.api.utils.enums import TipoUsuarioEnum
 
 router = APIRouter()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
@@ -33,9 +36,20 @@ async def atualizar_tarefa_base(
 
 
 @router.delete("/{tarefa_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def deletar_tarefa_base(tarefa_id: int, repository=Depends(get_repo())):
-    return await ServiceTarefaBase(repository).deletar_tarefa_base(tarefa_id)
+async def deletar_tarefa_base(tarefa_id: int, token: str = Depends(oauth2_scheme), repository=Depends(get_repo())):
+    
+    professor: Professor = await ServicoTipoUsuarioGenerico(
+        repository
+    ).buscar_usuario_atual(token=token)
 
+    if professor.usuario.tipo_usuario.titulo not in [
+        TipoUsuarioEnum.COORDENADOR,
+        TipoUsuarioEnum.PROFESSOR,
+    ]:
+        raise NaoAutorizadoException()
+    
+    await ServiceTarefaBase(repository).deletar_tarefa_base(tarefa_id)
+    return {"ok":True}
 
 @router.get("/{tarefa_id}", response_model=TarefaBaseInDB)
 async def buscar_tarefa_base(tarefa_id: int, repository=Depends(get_repo())):


### PR DESCRIPTION
## Descrição

FIXES #88 

IMPLEMENTAÇÕES:
- DELETE /tarefas/{tarefa_id} deve ser autenticado (receber token);
- DELETE /tarefas_base/{tarefa_id} deve ser autenticado (receber token);
- Apenas professores e coordenadores devem ser capazes de deletar tarefas.

## Que tipo de PR é este? (marque todos os aplicáveis)

- [x] 🍕 Recurso (Feature)
- [ ] 🐛 Correção de Erro (Bugfix)
- [ ] 📝 Atualização de Documentação
- [ ] 🎨 Estilização
- [ ] 🧑‍💻 Refatoração de Código
- [ ] 🔥 Melhorias de Desempenho
- [ ] ✅ Testes (unitários/integração/e2e)
- [ ] 🤖 Compilação
- [ ] 🔁 Integração Contínua
- [ ] 📦 Tarefa (Nova versão)
- [ ] ⏩ Reverter

## Issues/Tickets e Documentos Relacionados
#88 


## Capturas de Tela/Gravações para Dispositivos Móveis e Desktop
![image](https://github.com/user-attachments/assets/e211fbc3-b46d-4c9a-944f-404960a84dc1)


## Passos para a QA
Deletar tarefa:
- Com usuário não autenticado
- Autenticado como aluno
- Autenticado como professor
- Autenticado como coordenador

Deletar tarefa_base:
- Com usuário não autenticado
- Autenticado como aluno
- Autenticado como professor
- Autenticado como coordenador

## Adicionado à Documentação?

## [opcional] Existem tarefas pós-implementação que precisamos realizar?

Não se aplica